### PR TITLE
Fix typo in config comment

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -23,7 +23,7 @@ dateFormat = "January 2, 2006"
 since = 1980
 # Git Commit in Footer, uncomment the line below to enable it
 commit = "https://github.com/luizdepra/hugo-coder/tree/"
-# Right To Left, shift content direction for languagues such as Arabic
+# Right To Left, shift content direction for languages such as Arabic
 rtl = false
 # Specify light/dark colorscheme
 # Supported values:


### PR DESCRIPTION
## Summary
- correct a typo in the RTL comment in `config.toml`

## Testing
- `grep -n "languages" -n config.toml`

------
https://chatgpt.com/codex/tasks/task_e_68487b0ba828833086a7d07f40501236